### PR TITLE
pull private repo ewf-coo-matcher using ssh instead of https

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "csv-parse": "^2.5.0",
     "ethereumjs-tx": "^1.3.4",
     "ewf-coo": "git+https://github.com/energywebfoundation/ewf-coo.git",
-    "ewf-coo-matcher": "git+https://github.com/energywebfoundation/ewf_coo_matcher.git",
+    "ewf-coo-matcher": "git+ssh://git@github.com/energywebfoundation/ewf_coo_matcher.git",
     "http-server": "^0.11.1",
     "live-server": "^1.2.0",
     "node-sass": "^4.7.2",


### PR DESCRIPTION
npm install is failing to pull private repo ewf-coo-matcher using HTTPS.  I was able to successfully run npm install by switching to SSH. 